### PR TITLE
fix: also make it usable with raw files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ const withIosLinkedAsset: ConfigPlugin<Props> = (
 
     addResourceFile(font);
     addResourceFile(image);
+    addResourceFile(Object.values(rest).flat());
 
     return config;
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,12 @@ import {
 } from "@expo/config-plugins";
 import fs from "fs";
 import path from "path";
+
 const debug = require("debug")("bacons:link-assets");
 
 import { groupFilesByType } from "./groupFiles";
 
-type Props = {
-  font?: string[];
-  image?: string[];
-};
+type Props = Record<string, string[]>;
 
 const withLinkedAsset: ConfigPlugin<string[]> = (config, props) => {
   const expanded = props
@@ -37,27 +35,39 @@ const withLinkedAsset: ConfigPlugin<string[]> = (config, props) => {
   return config;
 };
 
-const withAndroidLinkedAsset: ConfigPlugin<Props> = (config, { font }) => {
+const withAndroidLinkedAsset: ConfigPlugin<Props> = (
+  config,
+  { font = [], ...raw }
+) => {
   withDangerousMod(config, [
     "android",
     (config) => {
-      (font || []).forEach((asset) => {
-        const fontsDir = path.join(
-          config.modRequest.platformProjectRoot,
-          "app/src/main/assets/fonts"
-        );
-        fs.mkdirSync(fontsDir, { recursive: true });
-        const output = path.join(fontsDir, path.basename(asset));
-        debug("Copying font:", asset, "to", output);
-        fs.copyFileSync(asset, output);
-      });
+      function addResourceFiles(assets: string[], directoryName: string) {
+        return assets.forEach((asset) => {
+          const dir = path.join(
+            config.modRequest.platformProjectRoot,
+            `app/src/main/res/${directoryName}`
+          );
+          fs.mkdirSync(dir, { recursive: true });
+          const output = path.join(dir, path.basename(asset));
+          debug("Copying asset:", asset, "to", output);
+          fs.copyFileSync(asset, output);
+        });
+      }
+
+      addResourceFiles(font, "fonts");
+      addResourceFiles(Object.values(raw).flat(), "raw");
+
       return config;
     },
   ]);
   return config;
 };
 
-const withIosLinkedAsset: ConfigPlugin<Props> = (config, { font, image }) => {
+const withIosLinkedAsset: ConfigPlugin<Props> = (
+  config,
+  { font = [], image = [], ...rest }
+) => {
   config = withXcodeProject(config, (config) => {
     const project = config.modResults;
 


### PR DESCRIPTION
Since [Rive](https://github.com/rive-app/rive-react-native) does not allow using expo assets URLs yet on Android, I needed to link assets in a more traditional way. 

With this change, I also allow files that are not image or font files. 

On top of that:
- Putting them in the res folder on Android since Rive expects this.
- Format the files I worked on with default prettier config